### PR TITLE
Add offline setup placeholders

### DIFF
--- a/.mvn/wrapper/maven-wrapper.jar
+++ b/.mvn/wrapper/maven-wrapper.jar
@@ -1,0 +1,1 @@
+placeholder

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,2 @@
+# Placeholder configuration
+distributionUrl=FILE:///path/to/apache-maven.zip

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # aitool
+
+This repository provides a minimal demonstration of a backend written in Spring Boot and a frontend using Node with Jest for testing. The environment lacks internet access, so you must provide dependencies offline.
+
+## Backend
+
+A simple Spring Boot application lives in the `backend` directory. Copy a Maven distribution to `./maven` and populate `offline-maven-repo` with the required artifacts. Then run:
+
+```bash
+./setup-backend.sh
+```
+
+## Frontend
+
+The `frontend` directory holds a small Node project with Jest. Place a pre-downloaded `node_modules` directory under `frontend/` or fill it using a local npm cache. Tests can then run with:
+
+```bash
+./setup-frontend.sh
+```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/backend/src/main/java/com/example/demo/DemoApplication.java
+++ b/backend/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,11 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/backend/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/backend/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,5 @@
+function sum(a, b) {
+  return a + b;
+}
+
+module.exports = { sum };

--- a/frontend/app.test.js
+++ b/frontend/app.test.js
@@ -1,0 +1,5 @@
+const { sum } = require('./app');
+
+test('adds numbers', () => {
+  expect(sum(1, 2)).toBe(3);
+});

--- a/frontend/node_modules/README.md
+++ b/frontend/node_modules/README.md
@@ -1,0 +1,3 @@
+# Offline Node Modules
+
+Place pre-downloaded dependencies here so `npm test --silent` can run offline.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 1,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.1.0",
+      "devDependencies": {
+        "jest": "^29.0.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.0.0",
+      "dev": true
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Simple Maven wrapper placeholder
+if [ -x "$(dirname "$0")/maven/bin/mvn" ]; then
+  MAVEN="$(dirname "$0")/maven/bin/mvn"
+else
+  MAVEN=mvn
+fi
+exec "$MAVEN" "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,9 @@
+
+@echo off
+
+set MAVEN_CMD=mvn
+
+if exist "%~dp0\maven\bin\mvn.cmd" set MAVEN_CMD=%~dp0\maven\bin\mvn.cmd
+
+"%MAVEN_CMD%" %*
+

--- a/offline-maven-repo/README.md
+++ b/offline-maven-repo/README.md
@@ -1,0 +1,4 @@
+# Offline Maven Repository
+
+This directory is intended to store Maven artifacts so the project can be built without network access.
+Populate it with the required dependencies prior to running `./mvnw -q test`.

--- a/setup-backend.sh
+++ b/setup-backend.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Placeholder setup for backend
+# Copy your offline Maven distribution to ./maven before running
+
+if [ ! -x "./maven/bin/mvn" ]; then
+  echo "Maven distribution missing. Copy it to ./maven" >&2
+  exit 1
+fi
+
+./mvnw -Dmaven.repo.local=./offline-maven-repo -q test

--- a/setup-frontend.sh
+++ b/setup-frontend.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Placeholder setup for frontend
+# Ensure node_modules contains jest before running
+
+if [ ! -d "frontend/node_modules/jest" ]; then
+  echo "Missing node_modules. Populate them before running." >&2
+  exit 1
+fi
+
+cd frontend && npm test --silent


### PR DESCRIPTION
## Summary
- provide scripts to run backend and frontend tests in offline mode
- add Maven wrapper placeholders and offline repository directory
- add placeholder node_modules directory and lock file
- document offline setup in README

## Testing
- `./setup-backend.sh` *(fails: Maven distribution missing)*
- `./setup-frontend.sh` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d57efc6a8832797998ad3ba121f31